### PR TITLE
💥 Replace overflow with numberOfLines

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -64,7 +64,8 @@ export interface TextProps extends ContainerProps {
   /** Specifies whether fonts should scale to respect Text Size accessibility settings on supported platforms. */
   allowFontScaling?: boolean
   color?: string
-  overflow?: 'ellipsis' | null
+  /** Limit the text to the specified number of lines. */
+  numberOfLines?: number | null
   size?: string | number
   weight?: 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900'
 }

--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ exports.Text = function Text (props) {
         borderWidth: (typeof props.borderWidth === 'number' ? (props.borderWidth + 'px') : props.borderWidth),
         boxSizing: 'border-box',
         color: props.color,
+        display: props.numberOfLines == null ? undefined : '-webkit-box',
         flexBasis: (typeof props.basis === 'number' ? (props.basis + 'px') : props.basis),
         flexGrow: props.grow,
         flexShrink: props.shrink,
@@ -78,7 +79,7 @@ exports.Text = function Text (props) {
         maxWidth: (typeof props.maxWidth === 'number' ? (props.maxWidth + 'px') : props.maxWidth),
         minHeight: (typeof props.minHeight === 'number' ? (props.minHeight + 'px') : props.minHeight),
         minWidth: (typeof props.minWidth === 'number' ? (props.minWidth + 'px') : props.minWidth),
-        overflow: props.overflow === 'ellipsis' ? 'hidden' : undefined,
+        overflow: props.numberOfLines == null ? undefined : 'hidden',
         overflowWrap: 'anywhere',
         paddingBottom: padding(props.paddingBottom, props.paddingVertical, props.padding),
         paddingLeft: padding(props.paddingLeft, props.paddingHorizontal, props.padding),
@@ -86,10 +87,11 @@ exports.Text = function Text (props) {
         paddingTop: padding(props.paddingTop, props.paddingVertical, props.padding),
         position: props.style && props.style.position,
         textAlign: props.align == null ? undefined : props.align,
-        textOverflow: props.overflow === 'ellipsis' ? 'ellipsis' : undefined,
-        whiteSpace: props.overflow === 'ellipsis' ? 'nowrap' : 'pre-wrap',
+        whiteSpace: 'pre-wrap',
         width: (typeof props.width === 'number' ? (props.width + 'px') : props.width),
-        wordBreak: 'break-word'
+        wordBreak: 'break-word',
+        WebkitBoxOrient: props.numberOfLines == null ? undefined : 'vertical',
+        WebkitLineClamp: props.numberOfLines == null ? undefined : props.numberOfLines
       }
     },
     props.children

--- a/index.native.js
+++ b/index.native.js
@@ -82,7 +82,7 @@ exports.Text = function Text (props) {
       Native.Text,
       {
         allowFontScaling: props.allowFontScaling,
-        numberOfLines: props.overflow === 'ellipsis' ? 1 : undefined,
+        numberOfLines: props.numberOfLines == null ? undefined : props.numberOfLines,
         style: {
           color: props.color,
           fontSize: props.size,

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ Property | Required | Type | Comment
 align | optional | `'left' \| 'right' \| 'center' \| 'justify' \| null`
 allowFontScaling | optional | `boolean` | Specifies whether fonts should scale to respect Text Size accessibility settings on supported platforms.
 color | optional | `string`
-overflow | optional | `'ellipsis' \| null`
+numberOfLines | optional | `number \| null` | Limit the text to the specified number of lines.
 size | optional | `string \| number`
 weight | optional | `'normal' \| 'bold' \| '100' \| '200' \| '300' \| '400' \| '500' \| '600' \| '700' \| '800' \| '900'`
 alignSelf | optional | `'baseline' \| 'center' \| 'end' \| 'start' \| 'stretch'` | Override alignment along the cross axis for this item.


### PR DESCRIPTION
Migration Guide:

You can now specify a specific number of lines to limit text to.

If you are currently using `overflow='ellipsis'` on a `Text` component, replace it with `numberOfLines={1}`.